### PR TITLE
fix: Timezone when comparing open PRs

### DIFF
--- a/cherrytree/branch.py
+++ b/cherrytree/branch.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 import click
@@ -122,7 +122,7 @@ class CherryTreeBranch:
             click.secho(f' ({len(blocking_prs)} blocking labels found)', fg="cyan")
             self.blocking_pr_ids += [pr.number for pr in blocking_prs]
         prs = deduplicate_prs(prs)
-        now = datetime.now()
+        now = datetime.now(tz=timezone.utc)
         prs.sort(
             key=lambda x: x.closed_at if x.closed_at is not None else now,
         )


### PR DESCRIPTION
## Description of the change

Fixes a bug when comparing PRs that are open. In that case, `closed_at` will be `None` and the value of `datetime.now()` will be used. The problem is that this value is not offset aware and the following error is thrown:

```
cherrytree/branch.py", line 126, in __init__
    prs.sort(
TypeError: can't compare offset-naive and offset-aware datetimes
```
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
